### PR TITLE
Add issue environment info to payload

### DIFF
--- a/sentry_mattermost/plugin.py
+++ b/sentry_mattermost/plugin.py
@@ -53,7 +53,7 @@ def get_tags(event):
 class PayloadFactory:
     @classmethod
     def render_text(cls, params):
-        template = "__{project}__\n__[{title}]({link})__ \n{culprit}\n"
+        template = "__{project}__|__{env}__\n__[{title}]({link})__ \n{culprit}\n"
         return template.format(**params)
 
     @classmethod
@@ -66,7 +66,8 @@ class PayloadFactory:
             "title": group.message_short.encode('utf-8'),
             "link": group.get_absolute_url(),
             "culprit": group.culprit.encode('utf-8'),
-            "project": project.name
+            "project": project.name,
+            "env": event.get_environment().name
         }
 
         if plugin.get_option('include_rules', project):


### PR DESCRIPTION
This PR help subscribers know quickly which environment the issues belong to (very helpful for projects run in multiple environments)

Demo:

![Screen Shot 2019-04-24 at 23 44 57](https://user-images.githubusercontent.com/22726858/56677589-0b090900-66eb-11e9-90c4-2ce97040f802.png)


